### PR TITLE
Change "@return void" to "@return string"

### DIFF
--- a/src/KKiernan/CaesarCipher.php
+++ b/src/KKiernan/CaesarCipher.php
@@ -53,13 +53,13 @@ class CaesarCipher
     /**
      * Runs the algorithm to encrypt or decrypt the given string.
      *
-     * @return void
+     * @return string
      */
     protected function run($string, $key)
     {
-        return implode(array_map(function ($char) use ($key) {
+        return implode('', array_map(function ($char) use ($key) {
             return $this->shift($char, $key);
-        }, str_split($string)), '');
+        }, str_split($string)));
     }
 
     /**


### PR DESCRIPTION
Changed the "@return void" to "@return string", because Void must not return a value.
Changed the order of `implode()`, now the first argument is the "glue", following the same order of the documentation.